### PR TITLE
Try again with ECDSA deploy key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
             git config user.name "ci-build"
       - add_ssh_keys:
           fingerprints:
-            - "07:14:17:3b:89:69:dc:de:57:7c:cb:d4:b7:63:f5:ad"
+            - "ba:bd:8b:3f:29:69:38:44:ce:b0:c3:72:4d:04:16:00"
       - run:
           name: Deploy docs to gh-pages branch
           command: gh-pages --dotfiles --message "[skip ci] Updates" --dist book


### PR DESCRIPTION
The previous build failed due to GitHub security considerations:

    Cloning into '../../usr/local/lib/node_modules/gh-pages/.cache/git@github.com!jfrimmel!gba-experiments.git'...
    ERROR: You're using an RSA key with SHA-1, which is no longer allowed. Please use a newer client or a different key type.
    Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.

    fatal: Could not read from remote repository.

This commit changes the fingerprint to a new ECDSA-key, which is already
set up on CircleCI and GitHub.