### PR TITLE
Don't put built docs in /book/book directory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: book
+          at: .
       - run:
           name: Disable jekyll builds
           command: touch book/.nojekyll


### PR DESCRIPTION
The attached workspace did contain a `book` folder, which was unpacked
into another `book` folder. This caused an unnecessary nesting level.